### PR TITLE
Support for parameters in localized strings

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+# Description
+
+Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+Fixes # (issue)
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+# How Has This Been Tested?
+
+Please list the tests files for your request. Please also list any relevant details for your test configuration
+
+- Test A
+- Test B
+
+# Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published in downstream modules

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -24,10 +24,11 @@ jobs:
 
             # TODO(fix): For some reason, github Actions cant find the header catch2.hpp
 
-            # - name: Test
-            #   run: |
-            #     cd build
-            #     cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON
-            #     make -j 2
-            #     cd tests
-            #     ./tests
+            - name: Test
+              run: |
+                sudo apt install catch2 -y
+                cd build
+                cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=On
+                make -j 2
+                cd tests
+                ./tests

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ possible to use, with easy integration into existing projects.
     - [Multiple languages](#multiple-languages)
     - [Multiple files](#multiple-files)
     - [Custom locales directory path](#custom-locales-directory-path)
+    - [Parameters in localized strings](#parameters-in-localized-strings)
 - [Planned features](#planned-features)
 
 ## Installation
@@ -57,6 +58,8 @@ int main()
     i18n::Translator t;
     
     std::cout << t.translate("hello", "basic") << std::endl;    // "Hello, world!"
+    // or
+    std::cout << t("hello", "basic") << std::endl;              // "Hello, world!"
     return 0;
 }
 ```
@@ -86,9 +89,9 @@ int main()
     config.supportedLocales = {"en", "fr"};
     i18n::Translator t(config);
     
-    std::cout << t.translate("hello", "basic") << std::endl;    // "Hello, world!"
+    std::cout << t("hello", "basic") << std::endl;    // "Hello, world!"
     t.setLocale("fr");
-    std::cout << t.translate("hello", "basic") << std::endl;    // "Bonjour, monde!"
+    std::cout << t("hello", "basic") << std::endl;    // "Bonjour, monde!"
     return 0;
 }
 ```
@@ -116,8 +119,8 @@ int main()
 {
     i18n::Translator t;
     
-    std::cout << t.translate("hello", "basic") << std::endl;    // "Hello, world!"
-    std::cout << t.translate("goodbye", "other") << std::endl;  // "Goodbye, world!"
+    std::cout << t("hello", "basic") << std::endl;    // "Hello, world!"
+    std::cout << t("goodbye", "other") << std::endl;  // "Goodbye, world!"
     return 0;
 }
 ```
@@ -140,10 +143,33 @@ int main()
     config.localesDir = "path/to/locales";
     i18n::Translator t(config);
     
-    std::cout << t.translate("hello", "basic") << std::endl;    // "Hello, world!"
+    std::cout << t("hello", "basic") << std::endl;    // "Hello, world!"
     return 0;
 }
 ```
+
+### Parameters in localized strings
+
+assets/locales/en/parameters.json
+```json
+{
+    "hello": "Hello, my name is {{ name }}!"
+}
+```
+
+```cpp
+#include <Translator.hpp>
+
+int main()
+{
+    i18n::Translator t;
+    
+    std::cout << t("hello", "parameters", {{ "name", "John" }}) << std::endl;    // "Hello, my name is John!"
+    return 0;
+}
+```
+
+The format `{{ paramName }}` is space sensitive, so `{{paramName}}` will not work.
 
 ## Planned features
 
@@ -151,3 +177,4 @@ int main()
 - [ ] Support for pluralization [(#2)](https://github.com/Sinan-Karakaya/cpp-i18n/issues/2)
 - [ ] Support for localization of numbers, dates, currencies, etc... [(#4)](https://github.com/Sinan-Karakaya/cpp-i18n/issues/4)
 - [ ] Support for automatically detecting multiple locales [(#3)](https://github.com/Sinan-Karakaya/cpp-i18n/issues/3)
+- [X] Support for parameters in localized strings

--- a/assets/locales/en/test_parameters.json
+++ b/assets/locales/en/test_parameters.json
@@ -1,0 +1,4 @@
+{
+  "test1": "My name is {{ name }}",
+  "test2": "My name is {{ name }} and I'm {{ age }} years old"
+}

--- a/assets/locales/fr/test_parameters.json
+++ b/assets/locales/fr/test_parameters.json
@@ -1,0 +1,4 @@
+{
+  "test1": "Mon nom est {{ name }}",
+  "test2": "Mon nom est {{ name }} et j'ai {{ age }} ans"
+}

--- a/include/Translator.hpp
+++ b/include/Translator.hpp
@@ -114,7 +114,8 @@ namespace i18n
          * @param ns Namespace of the key. (e.g. "home")
          * @return Translation of the key in the namespace. (e.g. "Hello")
          */
-        std::string translate(const std::string &key, const std::string &ns = "");
+        std::string translate(const std::string &key, const std::string &ns = "", const
+        std::unordered_map<std::string, std::string> &args = {});
 
         /**
          * @brief Get the translation of a key in a namespace.
@@ -122,7 +123,8 @@ namespace i18n
          * @param ns Namespace of the key. (e.g. "home")
          * @return Translation of the key in the namespace. (e.g. "Hello")
          */
-        std::string operator()(const std::string &key, const std::string &ns = "");
+        std::string operator()(const std::string &key, const std::string &ns = "", const
+        std::unordered_map<std::string, std::string> &args = {});
 
     private:
         bool m_loadLocalesDirectory();
@@ -131,6 +133,8 @@ namespace i18n
 
         void m_printError(const std::string &message) const;
         void m_printWarning(const std::string &message) const;
+
+        std::string m_replaceArgs(const std::string &rawString, const std::unordered_map<std::string, std::string> &args) const;
 
     private:
         LocaleConfig m_localeConfig;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,7 +11,7 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(Catch2)
 
-add_executable(tests src/basic.cpp)
+add_executable(tests src/basic.cpp src/parameters.cpp)
 target_link_libraries(tests PRIVATE nlohmann_json::nlohmann_json)
 target_link_libraries(tests PRIVATE Catch2::Catch2)
 target_link_libraries(tests PRIVATE cpp-i18n)

--- a/tests/src/parameters.cpp
+++ b/tests/src/parameters.cpp
@@ -1,0 +1,48 @@
+/*
+** EPITECH PROJECT, 2023
+** Project
+** File description:
+** parameters
+*/
+
+//#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+
+#include "Translator.hpp"
+
+TEST_CASE("Simple parameter", "[parameters]")
+{
+    i18n::LocaleConfig config;
+    config.supportedLocales = {"fr", "en"};
+    i18n::Translator t(config);
+
+    REQUIRE(t("test1", "test_parameters", {{ "name", "John" }}) == "My name is John");
+    t.setLocale("fr");
+    REQUIRE(t("test1", "test_parameters", {{ "name", "John" }}) == "Mon nom est John");
+}
+
+TEST_CASE("Multiple parameters", "[parameters]")
+{
+    i18n::LocaleConfig config;
+    config.supportedLocales = {"fr", "en"};
+    i18n::Translator t(config);
+
+    REQUIRE(t("test2", "test_parameters", {{ "name", "John" }, { "age", "20" }}) ==
+    "My name is John and I'm 20 years old");
+    t.setLocale("fr");
+    REQUIRE(t("test2", "test_parameters", {{ "name", "John" }, { "age", "20" }}) == "Mon nom est John et j'ai 20 ans");
+}
+
+TEST_CASE("Missing parameter", "[parameters]")
+{
+    i18n::Translator t;
+
+    REQUIRE(t("test1", "test_parameters") == "My name is {{ name }}");
+}
+
+TEST_CASE("Too many parameters given", "[parameters]")
+{
+    i18n::Translator t;
+
+    REQUIRE(t("test1", "test_parameters", {{ "name", "John" }, { "age", "20" }}) == "My name is John");
+}


### PR DESCRIPTION
# Description

This PR includes the support for parameters inside localized strings. Parameters are passed with an unordered_map of <string, string>, which could be improved in the future for a better version with variadic arguments of different types.

A template for future PR and a fix for the tests CI has also been included, as well as some minor modifications to the README.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please list the tests files for your request. Please also list any relevant details for your test configuration

- tests/src/parameters.cpp

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules